### PR TITLE
Synchronize speeds of entering, underground and leaving train

### DIFF
--- a/notes/ToDo.txt
+++ b/notes/ToDo.txt
@@ -1,4 +1,5 @@
 Limitations (in addition to below tasks):
+    - At the moment only trains with a locomotive up front can pass through the tunnel
     - Only try to send 1 train through a tunnel at once. It won't stop more, but will error if they can't come out smoothly.
     - Trains will avoid tunnels at present due to a pathing penalty. So either have no loops or force them to only choose between tunnels so they make the right choice.
     - Make a long lead up (50 tiles) where the train can only get to the tunnel. Can be bendy, but must have no junctions.

--- a/notes/ToDo.txt
+++ b/notes/ToDo.txt
@@ -1,5 +1,4 @@
 Limitations (in addition to below tasks):
-    - When trains are leaving a tunnel they will be pushed out at their full speed until they are fully out, then they will path normally. So no junctions straight after a tunnel portal.
     - Only try to send 1 train through a tunnel at once. It won't stop more, but will error if they can't come out smoothly.
     - Trains will avoid tunnels at present due to a pathing penalty. So either have no loops or force them to only choose between tunnels so they make the right choice.
     - Make a long lead up (50 tiles) where the train can only get to the tunnel. Can be bendy, but must have no junctions.

--- a/scripts/train-manager.lua
+++ b/scripts/train-manager.lua
@@ -242,6 +242,11 @@ TrainManager.TrainLeavingOngoing = function(event)
     end
 
     aboveTrainLeaving.speed = trainManagerEntry.aboveTrainLeavingSpeedSign * trainManagerEntry.speed
+    if aboveTrainLeaving.state == defines.train_state.on_the_path then
+        sourceTrain.manual_mode = false
+    else
+        sourceTrain.manual_mode = true
+    end
     sourceTrain.speed = trainManagerEntry.undergroundTrainSpeedSign * trainManagerEntry.speed
 
     aboveTrainLeaving.schedule = trainManagerEntry.origTrainSchedule


### PR DESCRIPTION
Fully synchronize the speeds of entering, underground and leaving train.
This allows trains to slow down or even stop while exiting the tunnel
and have that feed back to the underground and entering train.

This fixes the following limitation:

> - When trains are leaving a tunnel they will be pushed out at their full speed until they are fully out, then they will path normally. So no junctions straight after a tunnel portal.

