### PR TITLE
Slow down entire train if leaving part slows down due to pathing

### DIFF
--- a/scripts/train-manager.lua
+++ b/scripts/train-manager.lua
@@ -11,11 +11,11 @@ TrainManager.CreateGlobals = function()
         id = uniqiue id of this managed train passing through the tunnel.
         aboveTrainEntering = LuaTrain of the entering train on the world surface.
         aboveTrainEnteringId = The LuaTrain ID of the above Train Entering.
+        aboveTrainEnteringForwards = boolean if the train is moving forwards or backwards from its viewpoint.
         aboveTrainLeaving = LuaTrain of the train created leaving the tunnel on the world surface.
         aboveTrainLeavingId = The LuaTrain ID of the above Train Leaving.
         trainTravelDirection = defines.direction the train is heading in.
         trainTravelOrientation = the orientation of the trainTravelDirection.
-        trainTravellingForwards = boolean if the train is moving forwards or backwards from its viewpoint.
         surfaceEntrancePortal = the portal global object of the entrance portal for this tunnel usage instance.
         surfaceEntrancePortalEndSignal = the endSignal global object of the rail signal at the end of the entrance portal track (forced closed signal).
         surfaceExitPortal = the portal global object of the exit portal for this tunnel usage instance.
@@ -63,9 +63,9 @@ TrainManager.TrainEnteringInitial = function(trainEntering, surfaceEntrancePorta
     trainManagerEntry.aboveSurface = tunnel.aboveSurface
     trainManagerEntry.undergroundSurface = tunnel.undergroundSurface
     if trainManagerEntry.aboveTrainEntering.speed > 0 then
-        trainManagerEntry.trainTravellingForwards = true
+        trainManagerEntry.aboveTrainEnteringForwards = true
     else
-        trainManagerEntry.trainTravellingForwards = false
+        trainManagerEntry.aboveTrainEnteringForwards = false
     end
     trainManagerEntry.trainTravelOrientation = trainManagerEntry.trainTravelDirection / 8
     global.trainManager.enteringTrainIdToManagedTrain[trainEntering.id] = trainManagerEntry
@@ -88,8 +88,6 @@ TrainManager.TrainEnteringInitial = function(trainEntering, surfaceEntrancePorta
     local sourceTrain = trainManagerEntry.aboveTrainEntering
     local undergroundTrain = TrainManager.CopyTrainToUnderground(trainManagerEntry)
 
-    --Set the speed and correct if after setting the schedule if needed. Easier than trying to work out what way the trains are facing to each other.
-    undergroundTrain.speed = sourceTrain.speed
     local undergroundTrainEndScheduleTargetPos =
         Utils.ApplyOffsetToPosition(
         Utils.RotatePositionAround0(
@@ -115,11 +113,8 @@ TrainManager.TrainEnteringInitial = function(trainEntering, surfaceEntrancePorta
             }
         }
     }
-    undergroundTrain.manual_mode = false
-    if undergroundTrain.speed == 0 then
-        undergroundTrain.speed = 0 - sourceTrain.speed
-    end
     trainManagerEntry.undergroundTrain = undergroundTrain
+    TrainManager.SetUndergroundTrainSpeed(trainManagerEntry, math.abs(sourceTrain.speed))
 
     trainManagerEntry.undergroundLeavingEntrySignalPosition = Utils.ApplyOffsetToPosition(trainManagerEntry.surfaceExitPortal.entrySignals["out"].entity.position, trainManagerEntry.tunnel.undergroundModifiers.undergroundOffsetFromSurface)
 
@@ -131,14 +126,12 @@ TrainManager.TrainEnteringOngoing = function(event)
     local trainManagerEntry = global.trainManager.managedTrains[event.instanceId]
     --Need to create a dummy leaving train at this point to reserve the train limit.
     trainManagerEntry.aboveTrainEntering.manual_mode = true
+    TrainManager.SetAboveTrainEnteringSpeed(trainManagerEntry, TrainManager.GetTrainSpeed(trainManagerEntry))
+
     local nextStockAttributeName = "front_stock"
-    if (trainManagerEntry.aboveTrainEntering.speed < 0) then
+    -- aboveTrainEnteringForwards has been updated for us by SetAboveTrainEnteringSpeed()
+    if not trainManagerEntry.aboveTrainEnteringForwards then
         nextStockAttributeName = "back_stock"
-    end
-    if (trainManagerEntry.undergroundTrain.speed > 0 and trainManagerEntry.aboveTrainEntering.speed > 0) or (trainManagerEntry.undergroundTrain.speed < 0 and trainManagerEntry.aboveTrainEntering.speed < 0) then
-        trainManagerEntry.aboveTrainEntering.speed = trainManagerEntry.undergroundTrain.speed
-    else
-        trainManagerEntry.aboveTrainEntering.speed = 0 - trainManagerEntry.undergroundTrain.speed
     end
 
     if Utils.GetDistance(trainManagerEntry.aboveTrainEntering[nextStockAttributeName].position, trainManagerEntry.surfaceEntrancePortalEndSignal.entity.position) < 10 then
@@ -206,33 +199,34 @@ end
 TrainManager.TrainLeavingOngoing = function(event)
     local trainManagerEntry = global.trainManager.managedTrains[event.instanceId]
     local aboveTrainLeaving, sourceTrain = trainManagerEntry.aboveTrainLeaving, trainManagerEntry.undergroundTrain
+    local desiredSpeed = TrainManager.GetTrainSpeed(trainManagerEntry)
 
-    local currentSourceTrainCarriageIndex = trainManagerEntry.aboveTrainLeavingCarriagesPlaced
-    local nextSourceTrainCarriageIndex = currentSourceTrainCarriageIndex + 1
-    if (sourceTrain.speed < 0) then
-        currentSourceTrainCarriageIndex = #sourceTrain.carriages - trainManagerEntry.aboveTrainLeavingCarriagesPlaced
-        nextSourceTrainCarriageIndex = currentSourceTrainCarriageIndex
+    if sourceTrain.speed ~= 0 then
+        local currentSourceTrainCarriageIndex = trainManagerEntry.aboveTrainLeavingCarriagesPlaced
+        local nextSourceTrainCarriageIndex = currentSourceTrainCarriageIndex + 1
+        if (sourceTrain.speed < 0) then
+            currentSourceTrainCarriageIndex = #sourceTrain.carriages - trainManagerEntry.aboveTrainLeavingCarriagesPlaced
+            nextSourceTrainCarriageIndex = currentSourceTrainCarriageIndex
+        end
+
+        local currentSourceCarriageEntity, nextSourceCarriageEntity = sourceTrain.carriages[currentSourceTrainCarriageIndex], sourceTrain.carriages[nextSourceTrainCarriageIndex]
+        if nextSourceCarriageEntity == nil then
+            -- All wagons placed so tidy up
+            TrainManager.TrainLeavingCompleted(trainManagerEntry, desiredSpeed)
+            return
+        end
+        -- TODO: this isn't perfect, but pretty good and supports orientations.
+        if Utils.GetDistance(currentSourceCarriageEntity.position, trainManagerEntry.undergroundLeavingExitSignalPosition) > 10 then
+            local nextCarriagePosition = Utils.ApplyOffsetToPosition(nextSourceCarriageEntity.position, trainManagerEntry.tunnel.undergroundModifiers.surfaceOffsetFromUnderground)
+            nextSourceCarriageEntity.clone {position = nextCarriagePosition, surface = trainManagerEntry.aboveSurface}
+            trainManagerEntry.aboveTrainLeavingCarriagesPlaced = trainManagerEntry.aboveTrainLeavingCarriagesPlaced + 1
+            aboveTrainLeaving = trainManagerEntry.aboveTrainLeaving -- LuaTrain has been replaced and updated by adding a wagon, so obtain a local reference to it again.
+        end
     end
 
-    local currentSourceCarriageEntity, nextSourceCarriageEntity = sourceTrain.carriages[currentSourceTrainCarriageIndex], sourceTrain.carriages[nextSourceTrainCarriageIndex]
-    if nextSourceCarriageEntity == nil then
-        -- All wagons placed so tidy up
-        TrainManager.TrainLeavingCompleted(trainManagerEntry)
-        return
-    end
-    -- TODO: this isn't perfect, but pretty good and supports orientations.
-    if Utils.GetDistance(currentSourceCarriageEntity.position, trainManagerEntry.undergroundLeavingExitSignalPosition) > 10 then
-        local nextCarriagePosition = Utils.ApplyOffsetToPosition(nextSourceCarriageEntity.position, trainManagerEntry.tunnel.undergroundModifiers.surfaceOffsetFromUnderground)
-        nextSourceCarriageEntity.clone {position = nextCarriagePosition, surface = trainManagerEntry.aboveSurface}
-        trainManagerEntry.aboveTrainLeavingCarriagesPlaced = trainManagerEntry.aboveTrainLeavingCarriagesPlaced + 1
-        aboveTrainLeaving = trainManagerEntry.aboveTrainLeaving -- LuaTrain has been replaced and updated by adding a wagon, so obtain a local reference to it again.
-    end
+    TrainManager.SetTrainAbsoluteSpeed(aboveTrainLeaving, desiredSpeed)
+    TrainManager.SetUndergroundTrainSpeed(trainManagerEntry, desiredSpeed)
 
-    if (sourceTrain.speed > 0 and aboveTrainLeaving.speed > 0) or (sourceTrain.speed < 0 and aboveTrainLeaving.speed < 0) then
-        aboveTrainLeaving.speed = sourceTrain.speed
-    else
-        aboveTrainLeaving.speed = 0 - sourceTrain.speed
-    end
     aboveTrainLeaving.schedule = trainManagerEntry.origTrainSchedule
     aboveTrainLeaving.manual_mode = false
     if trainManagerEntry.origTrainScheduleStopEntity.trains_limit ~= Utils.MaxTrainStopLimit then
@@ -246,9 +240,10 @@ TrainManager.TrainLeavingOngoing = function(event)
     EventScheduler.ScheduleEvent(game.tick + 1, "TrainManager.TrainLeavingOngoing", trainManagerEntry.id)
 end
 
-TrainManager.TrainLeavingCompleted = function(trainManagerEntry)
+TrainManager.TrainLeavingCompleted = function(trainManagerEntry, speed)
     trainManagerEntry.aboveTrainLeaving.schedule = trainManagerEntry.origTrainSchedule
     trainManagerEntry.aboveTrainLeaving.manual_mode = false
+    TrainManager.SetTrainAbsoluteSpeed(trainManagerEntry.aboveTrainLeaving, speed)
 
     for _, carriage in pairs(trainManagerEntry.undergroundTrain.carriages) do
         carriage.destroy()
@@ -297,6 +292,79 @@ TrainManager.TrainLeavingOngoing_OnTrainCreated = function(event)
     global.trainManager.leavingTrainIdToManagedTrain[event.train.id] = managedTrain
 end
 
+TrainManager.SpeedGovernedByLeavingTrain = function(trainManagerEntry)
+    local train = trainManagerEntry.aboveTrainLeaving
+    if train and train.valid and train.state ~= defines.train_state.on_the_path then
+        return true
+    else
+        return false
+    end
+end
+
+-- determine the current speed of the train passing through the tunnel
+TrainManager.GetTrainSpeed = function(trainManagerEntry)
+    if TrainManager.SpeedGovernedByLeavingTrain(trainManagerEntry) then
+        return math.abs(trainManagerEntry.aboveTrainLeaving.speed)
+    else
+        return math.abs(trainManagerEntry.undergroundTrain.speed)
+    end
+end
+
+-- set speed of train while preserving direction
+TrainManager.SetTrainAbsoluteSpeed = function(train, speed)
+    if train.speed > 0 then
+        train.speed = speed
+    elseif train.speed < 0 then
+        train.speed = -1*speed
+    elseif speed ~= 0 then
+        -- this shouldn't be possible to reach, so throw an error for now
+        error "unable to determine train direction"
+    end
+end
+
+TrainManager.SetAboveTrainEnteringSpeed = function(trainManagerEntry, speed)
+    local train = trainManagerEntry.aboveTrainEntering
+
+    -- for the entering train the direction needs to be preserved in
+    -- global data, because it would otherwise get lost when the train
+    -- stops while entering the tunnel
+    if train.speed > 0 then
+        trainManagerEntry.aboveTrainEnteringForwards = true
+    elseif train.speed < 0 then
+        trainManagerEntry.aboveTrainEnteringForwards = false
+    end
+
+    -- entering train always kept on manual while its speed is managed
+    train.manual_mode = true
+
+    if trainManagerEntry.aboveTrainEnteringForwards then
+        train.speed = speed
+    else
+        train.speed = -1*speed
+    end
+end
+
+-- set the speed of the underground train
+-- train needs to be switched to manual if it is supposed to stop (speed=0)
+TrainManager.SetUndergroundTrainSpeed = function(trainManagerEntry, speed)
+    local train = trainManagerEntry.undergroundTrain
+
+    if speed ~= 0 or not TrainManager.SpeedGovernedByLeavingTrain(trainManagerEntry) then
+        if not train.manual_mode then
+            TrainManager.SetTrainAbsoluteSpeed(train, speed)
+        else
+            train.speed = speed
+            train.manual_mode = false
+            if train.speed == 0 then
+                train.speed = -1*speed
+            end
+        end
+    else
+        train.manual_mode = true
+        train.speed = 0
+    end
+end
+
 TrainManager.CopyTrainToUnderground = function(trainManagerEntry)
     local placedCarriage, refTrain, tunnel, targetSurface = nil, trainManagerEntry.aboveTrainEntering, trainManagerEntry.tunnel, trainManagerEntry.tunnel.undergroundSurface
 
@@ -335,7 +403,7 @@ TrainManager.CopyTrainToUnderground = function(trainManagerEntry)
     )
     local trainCarriagesOffset = Utils.RotatePositionAround0(trainManagerEntry.trainTravelOrientation, {x = 0, y = 7})
     local trainCarriagesForwardDirection = trainManagerEntry.trainTravelDirection
-    if not trainManagerEntry.trainTravellingForwards then
+    if not trainManagerEntry.aboveTrainEnteringForwards then
         trainCarriagesForwardDirection = Utils.LoopDirectionValue(trainCarriagesForwardDirection + 4)
     end
 


### PR DESCRIPTION
If the leaving part of the train slows down because of approaching a red
signal (or some other reason) this slows down the underground/entering
parts accordingly as well.